### PR TITLE
collect & store APP_EMAIL

### DIFF
--- a/overlay/usr/lib/inithooks/bin/foodsoft.py
+++ b/overlay/usr/lib/inithooks/bin/foodsoft.py
@@ -12,6 +12,7 @@ import os
 import sys
 import glob
 import getopt
+import inithooks_cache
 import string
 import subprocess
 from subprocess import Popen, PIPE
@@ -88,6 +89,8 @@ def main():
             "Foodsoft Email",
             "Enter email address for the Foodsoft 'admin' account.",
             "admin@example.com")
+
+    inithooks_cache.write('APP_EMAIL', email)
 
 
     variant_cur = os.path.basename(os.path.realpath(APP_DEFAULT_PATH))


### PR DESCRIPTION
Hi,

FYI we have added a feature so that TurnKey servers send alerts to the designated email address and it also auto signs users up to the security alerts (very low traffic) mail list. It is optional and can be skipped.

To make life easier for users, we now collect the email when the inithook firsts asks; then offer that as a suggestion later (instead of using admin@example.com again)..
